### PR TITLE
Added Docker support for building images and running tests with pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,57 @@ options:
   --verbose            enable verbose output
 ```
 
+## Using via Docker Image
+
+### Building the Docker Image
+
+You can build the Docker image for this project by running the following command:
+
+```bash
+python setup.py build_docker
+```
+
+OR directly from root project directory:
+
+```bash
+docker build --file docker/Dockerfile -t grep-ast-image .
+```
+
+### Calling grep-ast from Docker image
+
+To grep from current working directory we mount it to docker to give access so paths will work also inside docker, example:
+
+```
+docker run -it -v "$(pwd)":/app:ro grep-ast-image str grep_ast/*.py
+```
+
+### Using Docker image for pytest tests!
+
+To ensure reproducible testing and ease of debugging, you can run pytest tests inside the Docker image. This is particularly useful when collaborating in an open-source manner.
+
+You can use this docker image e.g. to run pytest:
+
+```bash
+python setup.py docker_test
+```
+
+OR directly:
+
+```
+docker run -it --entrypoint bash grep-ast-image -c 'cd /grep-ast; pwd; pytest'
+```
+
+This command will build the Docker image and execute pytest tests inside it.
+
+### If you want to debug Docker image itself
+
+If you want to execute commands inside docker image, overwrite entrypoint with bash and give it commands you want, examples:
+
+```bash
+$ docker run -it -v "$(pwd)":/app:ro --entrypoint bash grep-ast-image -c 'cd /app; pwd; ls'
+$ docker run -it --entrypoint bash grep-ast-image -c 'cd /grep-ast; pwd; ls'
+```
+
 ## Examples
 
 Here we search for **"encoding"** in the source to this tool:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.10-slim
+COPY . /grep-ast
+
+# Unfortunately to build the multi-arch docker image we need `build-essential` for amd64.
+# Apparently py-tree-sitter-languages doesn't have a pre-built binary wheel?
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y build-essential git libportaudio2 && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip install pytest && \
+    pip install --no-cache-dir /grep-ast
+WORKDIR /app
+ENTRYPOINT ["grep-ast"]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import re
+import subprocess
 
-from setuptools import find_packages, setup
+from setuptools import Command, find_packages, setup
 
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()
@@ -9,7 +10,61 @@ with open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
     long_description = re.sub(r"\n!\[.*\]\(.*\)", "", long_description)
 
+
+class BuildDockerImageCommand(Command):
+    description = "Build Docker image for the project"
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        command = ["docker", "build", "--file", "docker/Dockerfile", "-t", "grep-ast-image", "."]
+        subprocess.check_call(command)
+
+
+class DockerTestCommand(Command):
+    description = "Build Docker image and run pytest inside it"
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        build_command = [
+            "docker",
+            "build",
+            "--file",
+            "docker/Dockerfile",
+            "-t",
+            "grep-ast-image",
+            ".",
+        ]
+        test_command = [
+            "docker",
+            "run",
+            "-it",
+            "--entrypoint",
+            "bash",
+            "grep-ast-image",
+            "-c",
+            "cd /grep-ast; pytest",
+        ]
+        subprocess.check_call(build_command)
+        subprocess.check_call(test_command)
+
+
 setup(
+    cmdclass={
+        "build_docker": BuildDockerImageCommand,
+        "docker_test": DockerTestCommand,
+    },
     name="grep-ast",
     version="0.2.4",
     description="A tool to grep through the AST of a source file",


### PR DESCRIPTION
This commit introduces a new commands in setup.py that allows users to build the Docker image and run pytest tests inside it.

The README.md file has been updated to document this new feature, providing clear instructions for users to take advantage of reproducible testing environments.

* `python setup.py build_docker` to facilitate Docker image building.
* `python setup.py docker_test` for running pytest tests within the Docker container.
* Enhanced `README.md` with instructions on how to use the new `python setup.py build_docker` and `python setup.py docker_test` commands.
* The new Docker-related setup commands ensure consistent testing environments across different systems.
* These additions help maintain uniformity in test execution and assist in the debugging process for developers and contributors.