### PR TITLE
add terraform files extensions to parsers.py

### DIFF
--- a/grep_ast/parsers.py
+++ b/grep_ast/parsers.py
@@ -47,6 +47,8 @@ PARSERS = {
     ".scala": "scala",
     ".sql": "sql",
     ".sqlite": "sqlite",
+    ".tf": "hcl",
+    ".tfvars": "hcl",
     ".toml": "toml",
     ".tsq": "tsq",
     ".tsx": "typescript",


### PR DESCRIPTION
I'm working on integration of Terraform grammar to aider's repomap. This change is required in order to let aider find correct language