### PR TITLE
Handle empty files safely in verbose TreeContext output

### DIFF
--- a/grep_ast/grep_ast.py
+++ b/grep_ast/grep_ast.py
@@ -65,7 +65,6 @@ class TreeContext:
         self.walk_tree(root_node)
 
         if self.verbose:
-            # Empty files have num_lines==1, so range(num_lines-1) is empty.
             scope_width = max(
                 (len(str(set(self.scopes[i]))) for i in range(self.num_lines - 1)),
                 default=0,
@@ -278,7 +277,6 @@ class TreeContext:
             for k in dir(node):
                 print(k, getattr(node, k))
             """
-            # Empty/whitespace: named nodes may have empty text or start past splitlines().
             text_lines = node.text.splitlines()
             first_text = text_lines[0] if text_lines else b""
             line_text = self.lines[start_line] if start_line < len(self.lines) else ""

--- a/grep_ast/grep_ast.py
+++ b/grep_ast/grep_ast.py
@@ -65,7 +65,11 @@ class TreeContext:
         self.walk_tree(root_node)
 
         if self.verbose:
-            scope_width = max(len(str(set(self.scopes[i]))) for i in range(self.num_lines - 1))
+            # Empty files have num_lines==1, so range(num_lines-1) is empty.
+            scope_width = max(
+                (len(str(set(self.scopes[i]))) for i in range(self.num_lines - 1)),
+                default=0,
+            )
         for i in range(self.num_lines):
             header = sorted(self.header[i])
             if self.verbose and i < self.num_lines - 1:
@@ -274,12 +278,16 @@ class TreeContext:
             for k in dir(node):
                 print(k, getattr(node, k))
             """
+            # Empty/whitespace: named nodes may have empty text or start past splitlines().
+            text_lines = node.text.splitlines()
+            first_text = text_lines[0] if text_lines else b""
+            line_text = self.lines[start_line] if start_line < len(self.lines) else ""
             print(
                 "   " * depth,
                 node.type,
                 f"{start_line}-{end_line}={size + 1}",
-                node.text.splitlines()[0],
-                self.lines[start_line],
+                first_text,
+                line_text,
             )
 
         if size:

--- a/tests/test_tree_context.py
+++ b/tests/test_tree_context.py
@@ -1,0 +1,35 @@
+from grep_ast.grep_ast import TreeContext
+
+
+def test_verbose_empty_file_constructs():
+    tc = TreeContext("empty.py", "", verbose=True)
+    assert tc.lines == []
+    assert tc.num_lines == 1
+    assert tc.grep("x", False) == set()
+    tc.add_context()
+    assert tc.format() == ""
+
+
+def test_verbose_whitespace_only_file_constructs():
+    tc = TreeContext("ws.py", "   ", verbose=True)
+    assert tc.lines == ["   "]
+    assert tc.grep("x", False) == set()
+
+
+def test_verbose_newline_only_file_constructs():
+    # tree-sitter reports the module node on row 1, past splitlines()' single "".
+    tc = TreeContext("nl.py", "\n", verbose=True)
+    assert tc.lines == [""]
+    assert tc.num_lines == 2
+    assert tc.grep("x", False) == set()
+
+
+def test_verbose_normal_file_still_greps():
+    code = "def foo():\n    return 1\n"
+    tc = TreeContext("good.py", code, verbose=True)
+    assert tc.grep("foo", False) == {0}
+    tc.add_lines_of_interest({0})
+    tc.add_context()
+    out = tc.format()
+    assert "foo" in out
+    assert "return 1" in out


### PR DESCRIPTION
## Summary

`--verbose` / `TreeContext(..., verbose=True)` crashed with `IndexError` (and sometimes empty `max()`) on empty or whitespace-only files, aborting multi-file searches.

Skip or handle empty named nodes safely.

## Test plan

- tests for empty / whitespace-only verbose TreeContext